### PR TITLE
Node Modules in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# dependencies
+/node_modules


### PR DESCRIPTION
Node modules will not be pushed now, as requested in [#3](https://github.com/SRM-IST-KTR/HacktoberFest2022/issues/3)